### PR TITLE
Fix bug where fields in loaded dataset did not initialize

### DIFF
--- a/src/chart-transforms/encoding.js
+++ b/src/chart-transforms/encoding.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 
 import { SelectControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -244,6 +244,22 @@ export const SelectEncodingField = ( { setAttributes, json, field, label } ) => 
 			setAttributes( { json: updatedSpec } );
 		}
 	}, [ field, json, setAttributes ] );
+
+	const encodingField = getEncodingField( json, field );
+
+	// If the selected field is not available in the field options, pick one
+	// that is valid. This means that changing dataset will clear previous
+	// field settings in your chart.
+	useEffect( () => {
+		if ( ! fieldOptions.length || ! fieldOptions[0].value ) {
+			return;
+		}
+
+		const selectedOptionExists = ! ! fieldOptions.find( ( { value } ) => encodingField === value );
+		if ( ! selectedOptionExists ) {
+			onChangeField( fieldOptions[0].value );
+		}
+	}, [ encodingField, fieldOptions, onChangeField ] );
 
 	return (
 		<>


### PR DESCRIPTION
Steps to replicate:

1. Create a visualization block
2. Create or select a custom dataset

Expected:

- Sidebar options shows field source options from the loaded dataset
- Graph renders with the sources shown in the sidebar

Actual:

- Sidebar options shows field source options from the loaded dataset, but they are not actually reflected in the graph schema
- Graph does not render properly