### PR TITLE
Do not render Vega Lite actions menu

### DIFF
--- a/src/components/VegaChart/index.js
+++ b/src/components/VegaChart/index.js
@@ -16,10 +16,14 @@ const VegaChart = ( { spec } ) => {
 	const id = useMemo( () => sufficientlyUniqueId(), [] );
 
 	useEffect( () => {
-		vegaEmbed( `#${ id }`, {
-			$schema: 'https://vega.github.io/schema/vega-lite/v5.json',
-			...spec,
-		} );
+		vegaEmbed(
+			`#${ id }`,
+			{
+				$schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+				...spec,
+			},
+			{ actions: false }
+		);
 	}, [ container, id, spec ] );
 
 	return (

--- a/src/frontend.js
+++ b/src/frontend.js
@@ -41,7 +41,11 @@ function initializeDatavisBlock( element ) {
 	}
 
 	if ( typeof vegaEmbed === 'function' ) {
-		vegaEmbed( document.getElementById( element.dataset.datavis ), JSON.parse( jsonElement.textContent ) );
+		vegaEmbed(
+			document.getElementById( element.dataset.datavis ),
+			JSON.parse( jsonElement.textContent ),
+			{ actions: false }
+		);
 	}
 }
 


### PR DESCRIPTION
This could be made configurable longer-term but for now, we do not clearly need it, and it is distracting in both the editor and frontend

See menu in the upper right corner of this example:
<img width="484" alt="image" src="https://user-images.githubusercontent.com/442115/214053519-70e43215-8085-4f6e-97bc-8653b63ab64c.png">
