### PR TITLE
WMF-770: Fix issue where graphs do not render on frontend

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           BUILD_COMMAND_TARGET: 'build'
           CLEAN_TEST_TAG: true
-          CLEAN_TARGETS: .[!.]*,__tests__,src,package.json,package-lock.json,node_modules,tests,*.xml.dist
+          CLEAN_TARGETS: .[!.]*,__tests__,package.json,package-lock.json,node_modules,tests,*.xml.dist
           COMMIT_MESSAGE: "Built release for ${{ steps.get_version.outputs.VERSION }}. For a full change log look at the notes within the original/${{ steps.get_version.outputs.VERSION }} release."
           CREATE_MAJOR_VERSION_TAG: false
           CREATE_MINOR_VERSION_TAG: false

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -17,7 +17,7 @@ function bootstrap() : void {
 	}
 
 	add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_editor_assets' );
-	add_action( 'enqueue_block_assets', __NAMESPACE__ . '\\enqueue_vega' );
+	add_action( 'enqueue_block_assets', __NAMESPACE__ . '\\register_vega' );
 	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_frontend_assets' );
 }
 
@@ -29,7 +29,7 @@ function bootstrap() : void {
  *
  * @return void
  */
-function enqueue_vega() : void {
+function register_vega() : void {
 	$plugin_assets_dir = plugin_dir_url( __DIR__ ) . 'assets/';
 	wp_register_script( 'vega', $plugin_assets_dir . 'vega.5.21.0.js' );
 	wp_register_script( 'vega-lite', $plugin_assets_dir . 'vega-lite.5.2.0.js', [ 'vega' ] );

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -31,9 +31,9 @@ function bootstrap() : void {
  */
 function enqueue_vega() : void {
 	$plugin_assets_dir = plugin_dir_url( __DIR__ ) . 'assets/';
-	wp_enqueue_script( 'vega', $plugin_assets_dir . 'vega.5.21.0.js' );
-	wp_enqueue_script( 'vega-lite', $plugin_assets_dir . 'vega-lite.5.2.0.js', [ 'vega' ] );
-	wp_enqueue_script( 'vega-embed', $plugin_assets_dir . 'vega-embed.6.20.2.js', [ 'vega-lite' ] );
+	wp_register_script( 'vega', $plugin_assets_dir . 'vega.5.21.0.js' );
+	wp_register_script( 'vega-lite', $plugin_assets_dir . 'vega-lite.5.2.0.js', [ 'vega' ] );
+	wp_register_script( 'vega-embed', $plugin_assets_dir . 'vega-embed.6.20.2.js', [ 'vega-lite' ] );
 }
 
 /**
@@ -43,7 +43,7 @@ function enqueue_vega() : void {
  * @param string   $asset        Name of script in asset manifest.
  * @param string[] $dependencies Array of script dependencies.
  */
-function enqueue_build_asset( $handle, $asset, $dependencies = [] ) : void {
+function register_build_asset( $handle, $asset, $dependencies = [] ) : void {
 	$plugin_path = trailingslashit( plugin_dir_path( dirname( __FILE__, 1 ) ) );
 
 	$manifest = Asset_Loader\Manifest\get_active_manifest( [
@@ -51,7 +51,12 @@ function enqueue_build_asset( $handle, $asset, $dependencies = [] ) : void {
 		$plugin_path . 'build/production-asset-manifest.json',
 	] );
 
-	Asset_Loader\enqueue_asset( $manifest, $asset, [
+	if ( empty( $manifest ) ) {
+		trigger_error( "No manifest available for $asset", E_USER_WARNING );
+		return;
+	}
+
+	Asset_Loader\register_asset( $manifest, $asset, [
 		'handle' => $handle,
 		'dependencies' => $dependencies,
 	] );
@@ -61,7 +66,7 @@ function enqueue_build_asset( $handle, $asset, $dependencies = [] ) : void {
  * Enqueue these assets in the block editor.
  */
 function enqueue_editor_assets() : void {
-	enqueue_build_asset(
+	register_build_asset(
 		'vegalite-plugin-editor',
 		'vegalite-plugin-editor.js',
 		[
@@ -73,19 +78,19 @@ function enqueue_editor_assets() : void {
 			'vega-embed',
 		]
 	);
-	enqueue_build_asset( 'vegalite-plugin-editor', 'vegalite-plugin-editor.css' );
+	register_build_asset( 'vegalite-plugin-editor', 'vegalite-plugin-editor.css' );
 }
 
 /**
  * Enqueue these assets only on the frontend.
  */
 function enqueue_frontend_assets() : void {
-	enqueue_build_asset(
+	register_build_asset(
 		'vegalite-plugin-frontend',
 		'vegalite-plugin-frontend.js',
 		[ 'vega-embed' ]
 	);
-	enqueue_build_asset(
+	register_build_asset(
 		'vegalite-plugin-frontend',
 		'vegalite-plugin-frontend.css'
 	);

--- a/inc/datasets/metadata.php
+++ b/inc/datasets/metadata.php
@@ -27,6 +27,7 @@ function register_dataset_meta() {
 			META_KEY,
 			[
 				'single'       => true,
+				'type'         => 'array',
 				'default'      => [],
 				'show_in_rest' => false, // Use custom REST routes for management.
 			]

--- a/src/blocks/visualization/block.json
+++ b/src/blocks/visualization/block.json
@@ -5,6 +5,10 @@
 	"textdomain": "vegalite-plugin",
 	"category": "widgets",
 	"icon": "chart-line",
+	"editorScript": "vegalite-plugin-editor",
+	"editorStyle": "vegalite-plugin-editor",
+	"viewScript": "vegalite-plugin-frontend",
+	"viewStyle": "vegalite-plugin-frontend",
 	"attributes": {
 	  "chartId": {
 		"type": "string"


### PR DESCRIPTION
The root cause here is that we clean the `src` directory on build, which is necessary for the PHP-side block registration. Without access to the `block.json` files, PHP can't register the block and the PHP filter cannot take effect to render the proper output.

This PR does three things:

- [x] Do not clean `src/` directory on build, we need files within it in production.
- [x] Only enqueue block assets if the block exists on the page, for performance.
- [x] Set the type of registered metadata to suppress a doing_it_wrong warning.