### PR TITLE
Prepare v0.2.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Developed by [Human Made](https://humanmade.com) and the [Wikimedia Foundation](https://wikimediafoundation.org).
 
-Stable tag: 0.2.0
+Stable tag: 0.2.1
 
 This plugin provides a flexible data visualization block using the [Vega-Lite](https://vega.github.io/) declarative JSON visualization grammar.
 
@@ -70,6 +70,12 @@ Once a release has been created, update the release's description using GitHub's
 Any code merged into the `develop` branch will be build and committed to the `release-develop` branch. This branch can be used in non-production applications to validate and test proposed changes.
 
 ### Changelog
+
+**0.2.1**
+
+- Fix issue where blocks did not render on frontend due to block.json being deleted on build.
+- Fix issue where CSV meta was not registered as an array.
+- Fix issue where block scripts loaded on all pages, not only when a block is present.
 
 **0.2.0**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vegalite-plugin",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "A general-purpose WordPress data visualization block using the Vega visualization grammar",
   "engines": {

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Description: Provide a block to render graphics using Vega Lite.
  * Author: Human Made and the Wikimedia Foundation
  * Author URI: https://github.com/wikimedia/vegalite-wordpress-plugin/graphs/contributors
- * Version: 0.2.0
+ * Version: 0.2.1
  */
 
 namespace Vegalite_Plugin;


### PR DESCRIPTION
Ran `npm run bump:patch` and updated changelog.

- Fix issue where blocks did not render on frontend due to block.json being deleted on build.
- Fix issue where CSV meta was not registered as an array.
- Fix issue where block scripts loaded on all pages, not only when a block is present.