### PR TITLE
Update frontend style meta name to correct format

### DIFF
--- a/src/blocks/visualization/block.json
+++ b/src/blocks/visualization/block.json
@@ -8,7 +8,7 @@
 	"editorScript": "vegalite-plugin-editor",
 	"editorStyle": "vegalite-plugin-editor",
 	"viewScript": "vegalite-plugin-frontend",
-	"viewStyle": "vegalite-plugin-frontend",
+	"style": "vegalite-plugin-frontend",
 	"attributes": {
 	  "chartId": {
 		"type": "string"


### PR DESCRIPTION
After we made changes to only enqueue vega scripts when the block is present on page, we found a problem with the Responsive block showing extra space for the hidden version of the block, as described in this ticket:
https://github.com/humanmade/Wikimedia/issues/786

Original commit for these changes:
https://github.com/wikimedia/vegalite-wordpress-plugin/commit/4f13d54411fd9ffbb2bd1b6d424b19e04e367c4a

I discovered that the styles for hiding the empty container are getting registered but not enqueued because the `register_block_type_from_metadata` function expects the frontend styles to be called `style` in the block metadata.