### PR TITLE
922: Pin SHA1 of GitHub actions to ensure predictable version selection

### DIFF
--- a/.github/actions/build-to-release-branch/action.yml
+++ b/.github/actions/build-to-release-branch/action.yml
@@ -26,7 +26,7 @@ runs:
         git config user.email "<>"
 
     - name: Check out release branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         ref: ${{ inputs.release_branch }}
         fetch-depth: 0

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
         with:
           node-version: '18'
 
@@ -39,7 +39,7 @@ jobs:
 
       - name: Cache Dependencies
         id: npm-cache
-        uses: actions/cache@v3
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-npm-${{ steps.npm-cache-dir.outputs.node-version }}-${{ steps.npm-cache-dir.outputs.npm-version }}-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/php-standards.yml
+++ b/.github/workflows/php-standards.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Install PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@e6f75134d35752277f093989e72e140eaa222f35 # v2.28.0
         with:
           php-version: '8.1'
           coverage: none
@@ -40,7 +40,7 @@ jobs:
 
       - name: Cache PHP Dependencies
         id: composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
           path: ${{ steps.composer-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-composer-7.2-${{ hashFiles('composer.lock') }}
@@ -50,7 +50,7 @@ jobs:
           composer install --prefer-dist --no-progress --no-suggest --no-interaction
 
       - name: PHPCS cache
-        uses: actions/cache@v3
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
           path: tests/cache
           key: ${{ runner.os }}-phpcs-7.2-${{ hashFiles('plugin.php') }}

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
         with:
           node-version: '18'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
         with:
           node-version: '18'
 
@@ -19,7 +19,7 @@ jobs:
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
       - name: Create Release
-        uses: technote-space/release-github-actions@v8
+        uses: technote-space/release-github-actions@052f205daf62dff0c3ece009f07b38f3ec83e01a # v8.0.3
         with:
           BUILD_COMMAND_TARGET: 'build'
           CLEAN_TEST_TAG: true


### PR DESCRIPTION
Process for enacting this change:

For each `uses:` statement within the action configuration in the `.github/` folder, if the specified dependency action is a remote repository,

- Open that repository in GitHub
- Go to the releases page
- (Review changelog to determine whether we should expect a seamless upgrade)
- Copy the commit of the latest release
- Paste the commit in place of the `v#` string in the relevant YAML file
- Add a comment after the commit SHA1 explaining the corresponding version number