### PR TITLE
Prepare v0.3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Developed by [Human Made](https://humanmade.com) and the [Wikimedia Foundation](https://wikimediafoundation.org).
 
-Stable tag: 0.2.4
+Stable tag: 0.3.0
 
 This plugin provides a flexible data visualization block using the [Vega-Lite](https://vega.github.io/) declarative JSON visualization grammar.
 
@@ -71,7 +71,7 @@ Any code merged into the `develop` branch will be build and committed to the `re
 
 ### Changelog
 
-**0.2.4**
+**0.3.0**
 
 - Upgrade build dependencies for security and performance.
 - Pin the specific SHA1 commits of the GH actions

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Any code merged into the `develop` branch will be build and committed to the `re
 
 **0.3.0**
 
+- Upgrade [`vega-embed`](https://github.com/vega/vega-embed/releases) from 6.20.2 to 6.23.0; upgrade [`vega-lite`](https://github.com/vega/vega-lite/releases) from 5.2.0 to 5.16.3; upgrade [`vega`](https://github.com/vega/vega/releases) from 5.21.0 to 5.26.1
+
+**0.2.4**
+
 - Upgrade build dependencies for security and performance.
 - Pin the specific SHA1 commits of the GH actions
 - Update build actions to use Node.js version 18

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vegalite-plugin",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "private": true,
   "description": "A general-purpose WordPress data visualization block using the Vega visualization grammar",
   "engines": {

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Description: Provide a block to render graphics using Vega Lite.
  * Author: Human Made and the Wikimedia Foundation
  * Author URI: https://github.com/wikimedia/vegalite-wordpress-plugin/graphs/contributors
- * Version: 0.2.4
+ * Version: 0.3.0
  */
 
 namespace Vegalite_Plugin;


### PR DESCRIPTION
### Overview
This PR introduces version 0.3.0 of Vega Lite WordPress Plugin.

### Changes
- #33 