### PR TITLE
Encode stored spec as Base64 to avoid WP sanitizer corrupting stored specs

### DIFF
--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -47,7 +47,14 @@ jobs:
       - name: Install Dependencies
         run: npm install --legacy-peer-deps
 
-      - name: Run the build
+      - name: Run ESLint
         run: |
           npm run eslint
+
+      - name: Run unit tests
+        run: |
+          npm test
+
+      - name: Run the build
+        run: |
           npm run build

--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -143,7 +143,17 @@ function render_visualization_block( array $attributes, $content, $block ) : str
 		<?php maybe_render_attribute( 'data-min-width', $breakpoints['min_width'] ?? 0 ); ?>
 		<?php maybe_render_attribute( 'data-max-width', $breakpoints['max_width'] ?? 0 ); ?>
 	>
-		<script id="<?php echo esc_attr( $config ); ?>" type="application/json"><?php echo wp_kses_post( wp_json_encode( $json ) ); ?></script>
+		<script id="<?php echo esc_attr( $config ); ?>" type="application/json">
+			<?php
+			/*
+			 * Escape <, >, & and quotes as JSON \u sequences rather than HTML entities:
+			 * this prevents a </script> breakout without corrupting expressions such as
+			 * "datum.value >= 1000", which the browser does not decode inside a script
+			 * element's text content.
+			 */
+			echo wp_json_encode( $json, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
+			?>
+		</script>
 		<div id="<?php echo esc_attr( $datavis ); ?>" <?php maybe_render_attribute( 'style', $inline_style ); ?>></div>
 	</div>
 	<?php

--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -76,6 +76,32 @@ function maybe_render_attribute( string $attribute_name, $value ) : void {
 }
 
 /**
+ * Read the Vega Lite specification out of a block's attributes.
+ *
+ * Specs are stored base64-encoded so that content filters don't mess up chars
+ * like '>' within vega specifications.
+ *
+ * Blocks saved before 0.7 load the spec as a plain JSON object and remain
+ * readable until the post is migrated to the new format with a deprecation.
+ *
+ * @param array $attributes Block attributes.
+ * @return array|null Vega Lite specification, or null if none could be read.
+ */
+function get_chart_spec( array $attributes ) : ?array {
+	if ( ! empty( $attributes['chartSpec'] ) ) {
+		$decoded = base64_decode( $attributes['chartSpec'], true );
+		if ( $decoded === false ) {
+			return null;
+		}
+
+		$spec = json_decode( $decoded, true );
+		return is_array( $spec ) ? $spec : null;
+	}
+
+	return $attributes['json'] ?? null;
+}
+
+/**
  * Render function for block.
  *
  * @param array     $attributes Block attributes.
@@ -85,7 +111,7 @@ function maybe_render_attribute( string $attribute_name, $value ) : void {
  * @return string
  */
 function render_visualization_block( array $attributes, $content, $block ) : string {
-	$json     = $attributes['json'] ?? false;
+	$json     = get_chart_spec( $attributes );
 	$chart_id = $attributes['chartId'] ?? uniqid( 'chart-' );
 
 	$breakpoints = compute_breakpoint( $chart_id, $block->context['vegalite-plugin/breakpoints'] ?? [] );

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,16 @@
+const path = require( 'path' );
+
+module.exports = {
+	'preset': '@wordpress/jest-preset-default',
+
+	// Stand on top of the Babel config wp-scripts would use to generate Jest config.
+	'transform': {
+		'\\.[jt]sx?$': path.join(
+			path.dirname( require.resolve( '@wordpress/scripts/package.json' ) ),
+			'config/babel-transform'
+		),
+	},
+
+	// Merged with, not replacing, the preset's own setupFiles.
+	'setupFiles': [ '<rootDir>/jest.setup.js' ],
+};

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,8 @@
+/**
+ * Jest's jsdom environment does not expose TextEncoder or TextDecoder, which
+ * every browser provides. Use Node's spec-compliant implementations.
+ */
+const { TextDecoder, TextEncoder } = require( 'util' );
+
+global.TextEncoder = global.TextEncoder || TextEncoder;
+global.TextDecoder = global.TextDecoder || TextDecoder;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "phpcs": "composer lint",
     "start": "wp-scripts start",
     "build": "wp-scripts build",
+    "test": "wp-scripts test-unit-js",
     "bump:patch": "bump patch --commit 'Prepare v%s release' package.json README.md plugin.php",
     "bump:minor": "bump minor --commit 'Prepare v%s release' package.json README.md plugin.php",
     "bump:major": "bump major --commit 'Prepare v%s release' package.json README.md plugin.php"

--- a/src/blocks/visualization/EditVisualization.js
+++ b/src/blocks/visualization/EditVisualization.js
@@ -1,7 +1,7 @@
 /**
  * Edit function for Vega-Lite block.
  */
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 
 import {
 	useBlockProps,
@@ -19,6 +19,7 @@ import { ResizableChartPreview } from '../../chart-transforms/dimensions';
 import { ConditionalEncodingFields } from '../../chart-transforms/encoding';
 import ControlledJsonEditor from '../../components/ControlledJsonEditor';
 import DatasetEditor from '../../components/DatasetEditor';
+import { decodeSpec, encodeSpec } from '../../util/spec';
 import sufficientlyUniqueId from '../../util/sufficiently-unique-id';
 
 import defaultSpecification from './specification.json';
@@ -89,7 +90,32 @@ const tabs = [
  */
 const EditDatavisBlock = ( { attributes, setAttributes, isSelected } ) => {
 	const blockProps = useBlockProps();
-	const json = attributes.json || defaultSpecification;
+
+	// attributes.json is only reachable if a block hasn't been migrated to the
+	// encoded >= v0.7 format. Prefer it if present so that old specs still load
+	// and allow editing.
+	const json = useMemo(
+		() => decodeSpec( attributes.chartSpec ) || attributes.json || defaultSpecification,
+		[ attributes.chartSpec, attributes.json ]
+	);
+
+	// Every editor component below reads a spec object and writes it back as
+	// setAttributes( { json } ). Encode that object here so consumers do not
+	// need to worry about spec storage format.
+	const setSpecAttributes = useCallback( ( nextAttributes ) => {
+		if ( ! ( 'json' in nextAttributes ) ) {
+			setAttributes( nextAttributes );
+			return;
+		}
+
+		const { json: nextSpec, ...rest } = nextAttributes;
+		setAttributes( {
+			...rest,
+			chartSpec: encodeSpec( nextSpec ),
+			// Discard any legacy attribute this block was still carrying.
+			json: undefined,
+		} );
+	}, [ setAttributes ] );
 
 	// Ensure every visualization gets a unique chart ID.
 	useEffect( () => {
@@ -106,7 +132,7 @@ const EditDatavisBlock = ( { attributes, setAttributes, isSelected } ) => {
 			<ResizableChartPreview
 				id={ attributes.id }
 				json={ json }
-				setAttributes={ setAttributes }
+				setAttributes={ setSpecAttributes }
 				showHandles={ isSelected }
 			/>
 
@@ -122,7 +148,7 @@ const EditDatavisBlock = ( { attributes, setAttributes, isSelected } ) => {
 								return (
 									<ControlledJsonEditor
 										value={ json }
-										onChange={ ( json ) => setAttributes( { json } ) }
+										onChange={ ( json ) => setSpecAttributes( { json } ) }
 									/>
 								);
 							}
@@ -130,14 +156,14 @@ const EditDatavisBlock = ( { attributes, setAttributes, isSelected } ) => {
 								return (
 									<DatasetEditor
 										json={ json }
-										setAttributes={ setAttributes }
+										setAttributes={ setSpecAttributes }
 									/>
 								);
 							}
 							return null;
 						} }
 					</TabPanel>
-					<SidebarEditor json={ json } setAttributes={ setAttributes } />
+					<SidebarEditor json={ json } setAttributes={ setSpecAttributes } />
 				</>
 			) : null }
 		</div>

--- a/src/blocks/visualization/block.json
+++ b/src/blocks/visualization/block.json
@@ -13,6 +13,9 @@
 	  "chartId": {
 		"type": "string"
 	  },
+	  "chartSpec": {
+		"type": "string"
+	  },
 	  "json": {
 		"type": "object"
 	  }

--- a/src/blocks/visualization/index.js
+++ b/src/blocks/visualization/index.js
@@ -6,6 +6,8 @@ import { registerBlockType } from '@wordpress/blocks';
 import '../../store';
 import '../../type-definitions';
 
+import { encodeSpec } from '../../util/spec';
+
 import blockData from './block.json';
 import EditVisualization from './EditVisualization';
 
@@ -27,4 +29,55 @@ registerBlockType( blockData.name, {
 	save() {
 		return null;
 	},
+
+	deprecated: [
+		{
+			// Specs before 0.7 were stored as a plain object. Update on editor load
+			// into an encoded format that can't be mangled by WP's string sanitizer.
+			attributes: {
+				chartId: {
+					type: 'string',
+				},
+				json: {
+					type: 'object',
+				},
+			},
+
+			/**
+			 * Flag any block which still carries an unencoded spec.
+			 *
+			 * This block's save() returns null, so it can never be invalid;
+			 * opting in here is the only thing which triggers the migration.
+			 *
+			 * @param {object} attributes Attributes parsed from post content.
+			 * @returns {boolean} Whether this block needs migrating.
+			 */
+			isEligible( attributes ) {
+				return !! attributes.json;
+			},
+
+			/**
+			 * Replace the plain object spec with its encoded equivalent.
+			 *
+			 * @param {object} attributes      Attributes parsed from post content.
+			 * @param {object} attributes.json Vega Lite specification.
+			 * @returns {object} Migrated block attributes.
+			 */
+			migrate( { json, ...attributes } ) {
+				return {
+					...attributes,
+					chartSpec: encodeSpec( json ),
+				};
+			},
+
+			/**
+			 * Return null on save so rendering can be done in PHP.
+			 *
+			 * @returns {null} Empty so that server can complete rendering.
+			 */
+			save() {
+				return null;
+			},
+		},
+	],
 } );

--- a/src/util/spec.js
+++ b/src/util/spec.js
@@ -1,4 +1,60 @@
 /**
+ * Number of bytes to convert per String.fromCharCode call when encoding.
+ *
+ * @type {number}
+ */
+const CHUNK_SIZE = 0x8000;
+
+/**
+ * Serialize a Vega-Lite specification for storage in a block attribute.
+ *
+ * Attributes are stored as JSON within block content HTML, so they pass through
+ * WP's normal content filters and internal operators like > get encoded in a
+ * way that breaks parsing on next editor load.
+ *
+ * Serializing with Base64 keeps the spec within a safe character set.
+ *
+ * @param {object} spec Vega-Lite specification.
+ * @returns {string} Base64-encoded specification.
+ */
+export const encodeSpec = ( spec ) => {
+	const bytes = new TextEncoder().encode( JSON.stringify( spec ) );
+
+	// Convert in chunks: spreading a large byte array into String.fromCharCode
+	// overflows the call stack, and specs with inline datasets get large.
+	let binary = '';
+	for ( let i = 0; i < bytes.length; i += CHUNK_SIZE ) {
+		binary += String.fromCharCode.apply( null, bytes.subarray( i, i + CHUNK_SIZE ) );
+	}
+
+	return window.btoa( binary );
+};
+
+/**
+ * Restore a Vega-Lite specification from a stored block attribute value.
+ *
+ * @param {?string} encoded Base64-encoded specification.
+ * @returns {?object} Vega-Lite specification, or null if it could not be read.
+ */
+export const decodeSpec = ( encoded ) => {
+	if ( ! encoded ) {
+		return null;
+	}
+
+	try {
+		const bytes = Uint8Array.from(
+			window.atob( encoded ),
+			( character ) => character.charCodeAt( 0 )
+		);
+		return JSON.parse( new TextDecoder().decode( bytes ) );
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Could not decode chart specification.', error );
+		return null;
+	}
+};
+
+/**
  * Helper to figure out which available dataset has been set by URL in a spec.
  *
  * Returns the option to manage data inline, if not present.

--- a/src/util/spec.test.js
+++ b/src/util/spec.test.js
@@ -1,0 +1,83 @@
+import { decodeSpec, encodeSpec } from './spec';
+
+/**
+ * Spec using characters outside the Basic Latin range: Japanese for three-byte
+ * UTF-8, emoji for four-byte UTF-16 (UTF-8 'surrogate pair').
+ *
+ * @type {object}
+ */
+const multiByteSpec = {
+	'$schema': 'https://vega.github.io/schema/vega-lite/v6.json',
+	data: { url: 'data/movies.json' },
+	width: 200,
+	height: 100,
+	transform: [ {
+		density: 'IMDB Rating',
+		bandwidth: 0.3,
+	} ],
+	mark: 'area',
+	encoding: {
+		x: {
+			field: 'value',
+			title: '美味しさ',
+			type: 'quantitative',
+		},
+		y: {
+			field: 'density',
+			title: '🤤🤤🤤',
+			type: 'quantitative',
+		},
+	},
+};
+
+describe( 'encodeSpec / decodeSpec', () => {
+	it( 'correctly encodes and decodes an ASCII spec', () => {
+		const spec = {
+			mark: 'bar',
+			encoding: { x: { field: 'a > b' } },
+		};
+
+		expect( decodeSpec( encodeSpec( spec ) ) ).toEqual( spec );
+	} );
+
+	it( 'correctly encodes and decodes non-ASCII and emoji characters', () => {
+		const decoded = decodeSpec( encodeSpec( multiByteSpec ) );
+
+		expect( decoded ).toEqual( multiByteSpec );
+		expect( decoded.encoding.x.title ).toBe( '美味しさ' );
+		expect( decoded.encoding.y.title ).toBe( '🤤🤤🤤' );
+	} );
+
+	it( 'encodes multi-byte characters within the Base64 alphabet', () => {
+		// The point of encoding is to keep the attribute value safe to embed in
+		// block comment HTML, so nothing outside Base64 may survive encoding.
+		expect( encodeSpec( multiByteSpec ) ).toMatch( /^[A-Za-z0-9+/]+={0,2}$/ );
+	} );
+
+	it( 'correctly encodes and decodes multi-byte characters spanning the internal chunk boundary', () => {
+		// encodeSpec builds its binary string in 0x8000-byte chunks. Chunks are
+		// cut on byte boundaries, so a single character's bytes can land in two
+		// different chunks; sweep the padding length to cover each alignment.
+		for ( let padding = 0x8000 - 8; padding <= 0x8000; padding++ ) {
+			const spec = {
+				description: `${ 'x'.repeat( padding ) }🤤美`,
+				mark: 'area',
+			};
+
+			expect( decodeSpec( encodeSpec( spec ) ) ).toEqual( spec );
+		}
+	} );
+
+	it( 'returns null for an empty attribute value', () => {
+		expect( decodeSpec( '' ) ).toBeNull();
+		expect( decodeSpec( null ) ).toBeNull();
+		expect( decodeSpec( undefined ) ).toBeNull();
+	} );
+
+	it( 'returns null when the value is not a valid encoded spec', () => {
+		// eslint-disable-next-line no-console
+		console.error = jest.fn();
+
+		expect( decodeSpec( 'not base64 at all!' ) ).toBeNull();
+	} );
+} );


### PR DESCRIPTION
If you have a block like 

```
          "calculate": "datum.value >= 1000000000 ? '$' + format(datum.value / 1000000000, '.2f') + 'B' : '$' + format(floor(datum.value / 1000000), ',.0f') + 'M'",
```

then kses corrupts that data when stored and when output, breaking the formula by encoding `>`. Switching to have the payload converted into base64 and then passed through `escape_json` on output fixes this and prevents data storage from breaking chart initialization due to malformed spec markup.