### PR TITLE
Prevent charts from overflowing their content

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,14 @@
+{
+	"port": 8343,
+	"testsEnvironment": false,
+	"config": {
+		"SCRIPT_DEBUG": true,
+		"WP_DEBUG_DISPLAY": false,
+		"WP_DEBUG": true,
+		"WP_DEVELOPMENT_MODE": "plugin"
+	},
+	"plugins": [
+		".",
+		"https://downloads.wordpress.org/plugin/query-monitor.zip"
+	]
+}

--- a/README.md
+++ b/README.md
@@ -72,8 +72,22 @@ Other useful commands
 
 - `npm run lint`: Use ESLint to check src code for errors.
 
-----
+### Local Environment
 
+This project uses [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/) to run a lightweight, containerized WordPress instance at [localhost:8343](http://localhost:8343) for testing purposes. (8343 is "vega" on a phone keypad.) The default username for the localhost environment is `admin`, with the password `password`.
+
+These commands can be used to interact with the environment:
+
+Command | Purpose
+---- | ----
+`npm run env:start` | Start the local environment at http://localhost:8343
+`npm run env:stop` | Turn off the local environment
+`npm run env:cli -- wp ...` | Run WP-CLI commands within the environment
+`npm run env:logs` | Open (and tail) the error logs for the application<sup>&ddagger;</sup>
+`npm run env:db` | Open the database in the mysql command line
+`npm run env:destroy` | Fully destroy the local environment (deletes container database)
+
+<sup>&ddagger;</sup> This command deliberately filters out GET/OPTIONS/HEAD/POST/PUT access log entries
 
 ## Release Process
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -67,4 +67,19 @@ export default [
 			'import/no-extraneous-dependencies': 'off',
 		},
 	},
+
+	{
+		files: [
+			'**/*.test.js',
+			'**/*.spec.js',
+			'**/__tests__/**/*.js',
+			'jest.setup.js',
+		],
+		languageOptions: {
+			globals: {
+				...globals.jest,
+				...globals.node,
+			},
+		},
+	},
 ];

--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -124,13 +124,19 @@ function render_visualization_block( array $attributes, $content, $block ) : str
 	$datavis = sprintf( '%1$s-datavis', $chart_id );
 	$config  = sprintf( '%1$s-config', $chart_id );
 
-	// If we know the target dimensions, set those on the container to minimize CLS.
+	// Reserve space for the container, to minimize CLS. Write a max-width and aspect
+	// ratio so browser reserve space properly even when chart is capped in width.
+	$width  = isset( $json['width'] ) && is_numeric( $json['width'] ) ? (int) $json['width'] : 0;
+	$height = isset( $json['height'] ) && is_numeric( $json['height'] ) ? (int) $json['height'] : 0;
+
 	$inline_style = [];
-	if ( isset( $json['width'] ) && is_numeric( $json['width'] ) ) {
-		$inline_style[] = sprintf( 'width:%dpx', $json['width'] );
+	if ( $width ) {
+		$inline_style[] = sprintf( 'max-width:%dpx', $width );
 	}
-	if ( isset( $json['height'] ) && is_numeric( $json['height'] ) ) {
-		$inline_style[] = sprintf( 'height:%dpx', $json['height'] );
+	if ( $width && $height ) {
+		$inline_style[] = sprintf( 'aspect-ratio:%d/%d', $width, $height );
+	} elseif ( $height ) {
+		$inline_style[] = sprintf( 'height:%dpx', $height );
 	}
 	$inline_style = implode( ';', $inline_style );
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,10 @@
 const path = require( 'path' );
 
 module.exports = {
-	'preset': '@wordpress/jest-preset-default',
+	preset: '@wordpress/jest-preset-default',
 
 	// Stand on top of the Babel config wp-scripts would use to generate Jest config.
-	'transform': {
+	transform: {
 		'\\.[jt]sx?$': path.join(
 			path.dirname( require.resolve( '@wordpress/scripts/package.json' ) ),
 			'config/babel-transform'
@@ -12,5 +12,5 @@ module.exports = {
 	},
 
 	// Merged with, not replacing, the preset's own setupFiles.
-	'setupFiles': [ '<rootDir>/jest.setup.js' ],
+	setupFiles: [ '<rootDir>/jest.setup.js' ],
 };

--- a/package.json
+++ b/package.json
@@ -28,6 +28,12 @@
     "start": "wp-scripts start",
     "build": "wp-scripts build",
     "test": "wp-scripts test-unit-js",
+    "env:cli": "npx @wordpress/env run cli",
+    "env:db": "npx @wordpress/env run cli -- mysql -uroot -ppassword wordpress --host=mysql",
+    "env:destroy": "npx @wordpress/env destroy",
+    "env:logs": "npx @wordpress/env logs development | grep -v -E '\"(GET|OPTIONS|HEAD|POST|PUT)'",
+    "env:start": "npx @wordpress/env start",
+    "env:stop": "npx @wordpress/env stop",
     "bump:patch": "bump patch --commit 'Prepare v%s release' package.json README.md plugin.php",
     "bump:minor": "bump minor --commit 'Prepare v%s release' package.json README.md plugin.php",
     "bump:major": "bump major --commit 'Prepare v%s release' package.json README.md plugin.php"

--- a/src/blocks/visualization/edit-visualization.scss
+++ b/src/blocks/visualization/edit-visualization.scss
@@ -1,3 +1,9 @@
+// The resize box needs to be constrained the same way the chart is, or else
+// its handles won't line up with the chart in the editor.
+.wp-block-vegalite-plugin-visualization .components-resizable-box__container {
+	max-width: 100%;
+}
+
 .visualization-block-tabs {
 
 	[role="tablist"] {

--- a/src/blocks/visualization/style.scss
+++ b/src/blocks/visualization/style.scss
@@ -14,3 +14,18 @@
 .chart-hidden div {
 	display: none;
 }
+
+// Keep charts constained to their content column. Scales proportionally with
+// the viewBox from vega chart output as long as height is set to auto.
+.visualization-block,
+.wp-block-vegalite-plugin-visualization {
+
+	.vega-embed {
+		max-width: 100%;
+	}
+
+	.vega-embed > svg {
+		max-width: 100%;
+		height: auto;
+	}
+}

--- a/src/chart-transforms/dimensions.js
+++ b/src/chart-transforms/dimensions.js
@@ -52,21 +52,12 @@ export const ResizableChartPreview = ( { id, json, setAttributes, showHandles } 
 		);
 	}
 
-	const width = json.width || 400;
-	const height = json.height || 200;
+	// Constrain only the width. Height is left to the box so that it tracks the
+	// chart, which CSS scales down when the authored width does not fit.
 	const dimensionProps = {};
-	if ( json.width && json.height ) {
+	if ( json.width ) {
 		dimensionProps.size = {
-			width,
-			height,
-		};
-	} else if ( json.width ) {
-		dimensionProps.size = {
-			width,
-		};
-	} else if ( json.height ) {
-		dimensionProps.size = {
-			height,
+			width: json.width,
 		};
 	}
 
@@ -77,14 +68,17 @@ export const ResizableChartPreview = ( { id, json, setAttributes, showHandles } 
 			enable={ enableWidthAndHeightOnly }
 			defaultSize="auto"
 			{ ...dimensionProps }
-			onResizeStop={ ( event, direction, elt, delta ) => {
+			onResizeStop={ ( event, direction, elt ) => {
+				// Commit the size the box actually ended up at, not the authored
+				// value plus the drag delta: a chart scaled down to fit its
+				// container must not snap back to its original overflowing size.
 				// Only update a dimension if the user interaction provided a
-				// value for that dimension. (Allows height to remain "auto").
+				// value for it (allows height to remain "auto").
 				const newWidth = [ 'right', 'bottomRight' ].includes( direction )
-					? width + delta.width
+					? elt.offsetWidth
 					: null;
 				const newHeight = [ 'bottom', 'bottomRight' ].includes( direction )
-					? height + delta.height
+					? elt.offsetHeight
 					: null;
 
 				setAttributes( {

--- a/src/util/spec.test.js
+++ b/src/util/spec.test.js
@@ -7,7 +7,7 @@ import { decodeSpec, encodeSpec } from './spec';
  * @type {object}
  */
 const multiByteSpec = {
-	'$schema': 'https://vega.github.io/schema/vega-lite/v6.json',
+	$schema: 'https://vega.github.io/schema/vega-lite/v6.json',
 	data: { url: 'data/movies.json' },
 	width: 200,
 	height: 100,


### PR DESCRIPTION
This PR adds CSS guards (and adjusts how we write style attributes) to make charts behave more predictably within columns of content. They should not overflow their columns, so these rules keep them constrained properly and ensure they display consistently in the editor and frontend.